### PR TITLE
Tabs not spaces

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,5 @@
   "wpilib.online": true,
   "java.format.settings.url": "https://raw.githubusercontent.com/RoboticsTeam4904/4904matter/master/4904matter.xml",
   "editor.detectIndentation": false,
-  "editor.insertSpaces": false
+  "editor.insertSpaces": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,4 +12,6 @@
   },
   "wpilib.online": true,
   "java.format.settings.url": "https://raw.githubusercontent.com/RoboticsTeam4904/4904matter/master/4904matter.xml",
+  "editor.detectIndentation": false,
+  "editor.insertSpaces": false
 }


### PR DESCRIPTION
Change VSCode to use Tabs by default and regardless of the current formatting of the file (for only this workspace, 2019-Code)